### PR TITLE
Enh component active pixel

### DIFF
--- a/doc/user_guide/model.rst
+++ b/doc/user_guide/model.rst
@@ -152,7 +152,7 @@ back to `True`.
     In multidimensional signals it is possible to store the value of the
     :py:attr:`~.component.Component.active` attribute at each navigation index.
     To enable this feature for a given component set the
-    :py:attr:`~.component.Component.enable_pixel_level_switching` attribute to
+    :py:attr:`~.component.Component.active_is_multidimensional` attribute to
     `True`. 
 
     .. code-block:: python
@@ -162,7 +162,7 @@ back to `True`.
         >>> g1 = components.Gaussian()
         >>> g2 = components.Gaussian()
         >>> m.extend([g1,g2])
-        >>> g1.enable_pixel_level_switching = True
+        >>> g1.active_is_multidimensional = True
         >>> g1._active_array
         array([ True,  True,  True,  True,  True,  True,  True,  True,  True,  True], dtype=bool)
         >>> g2._active_array is None
@@ -173,7 +173,7 @@ back to `True`.
         >>> m.set_component_active_value(True, only_current=True)
         >>> g1._active_array
         array([ True, False, False, False, False, False, False, False, False, False], dtype=bool)
-        >>> g1.enable_pixel_level_switching = False
+        >>> g1.active_is_multidimensional = False
         >>> g1._active_array is None
         True
  

--- a/hyperspy/component.py
+++ b/hyperspy/component.py
@@ -454,39 +454,39 @@ class Component(object):
         self._position = None
         self.model = None
 
-    _pixel_level_switching = False
+    _active_is_multidimensional = False
     _active = True
 
     @property
-    def enable_pixel_level_switching(self):
-        return self._pixel_level_switching
+    def active_is_multidimensional(self):
+        return self._active_is_multidimensional
 
-    @enable_pixel_level_switching.setter
-    def enable_pixel_level_switching(self, value):
+    @active_is_multidimensional.setter
+    def active_is_multidimensional(self, value):
         if not isinstance(value, bool):
             raise ValueError('Only boolean values are permitted')
 
-        if value == self.enable_pixel_level_switching:
+        if value == self.active_is_multidimensional:
             warnings.warn(
-                'Pixel level component switching is already %s for %s' %
+                '`active_is_multidimensional` already %s for %s' %
                 (str(value), self.name), RuntimeWarning)
             return
 
         if value:  # Turn on
             if self._axes_manager.navigation_size < 2:
                 warnings.warn(
-                    'Only a single pixel in the signal, skipping',
+                    '`navigation_size` < 2, skipping',
                     RuntimeWarning)
                 return
             # Store value at current position
             self._create_active_array()
             self._store_active_value_in_array(self._active)
-            self._pixel_level_switching = True
+            self._active_is_multidimensional = True
         else:  # Turn off
             # Get the value at the current position before switching it off
             self._active = self.active
             self._active_array = None
-            self._pixel_level_switching = False
+            self._active_is_multidimensional = False
 
     @property
     def name(self):
@@ -526,7 +526,7 @@ class Component(object):
 
     @property
     def active(self):
-        if self.enable_pixel_level_switching is True:
+        if self.active_is_multidimensional is True:
             # The following should set
             self.active = self._active_array[self._axes_manager.indices[::-1]]
         return self._active
@@ -539,7 +539,7 @@ class Component(object):
         if self._active == arg:
             return
         self._active = arg
-        if self.enable_pixel_level_switching is True:
+        if self.active_is_multidimensional is True:
             self._store_active_value_in_array(arg)
 
         for f in self.connected_functions:
@@ -620,7 +620,7 @@ class Component(object):
             self._active_array = np.ones(shape, dtype=bool)
 
     def _create_arrays(self):
-        if self.enable_pixel_level_switching:
+        if self.active_is_multidimensional:
             self._create_active_array()
         for parameter in self.parameters:
             parameter._create_array()
@@ -630,7 +630,7 @@ class Component(object):
             parameter.store_current_value_in_array()
 
     def fetch_stored_values(self, only_fixed=False):
-        if self.enable_pixel_level_switching:
+        if self.active_is_multidimensional:
             # Store the stored value in self._active and trigger the connected
             # functions.
             self.active = self.active

--- a/hyperspy/model.py
+++ b/hyperspy/model.py
@@ -1930,7 +1930,7 @@ class Model(list):
 
         for _component in component_list:
             _component.active = value
-            if _component.enable_pixel_level_switching:
+            if _component.active_is_multidimensional:
                 if only_current:
                     _component._active_array[
                         self.axes_manager.indices[

--- a/hyperspy/tests/model/test_component.py
+++ b/hyperspy/tests/model/test_component.py
@@ -17,35 +17,35 @@ class TestMultidimensionalActive:
         c = self.c
         c._axes_manager.indices = (1, 1)
         c.active = True
-        c.enable_pixel_level_switching = True
+        c.active_is_multidimensional = True
         nose.tools.assert_true(np.all(c._active_array))
 
     def test_enable_pixel_switching_current_off(self):
         c = self.c
         c._axes_manager.indices = (1, 1)
         c.active = False
-        c.enable_pixel_level_switching = True
+        c.active_is_multidimensional = True
         nose.tools.assert_false(self.c.active)
 
     def test_disable_pixel_switching(self):
         c = self.c
         c.active = True
-        c.enable_pixel_level_switching = True
-        c.enable_pixel_level_switching = False
+        c.active_is_multidimensional = True
+        c.active_is_multidimensional = False
         nose.tools.assert_is(c._active_array, None)
 
     def test_disable_pixel_switching_current_on(self):
         c = self.c
         c._axes_manager.indices = (1, 1)
         c.active = True
-        c.enable_pixel_level_switching = True
-        c.enable_pixel_level_switching = False
+        c.active_is_multidimensional = True
+        c.active_is_multidimensional = False
         nose.tools.assert_true(c.active)
 
     def test_disable_pixel_switching_current_off(self):
         c = self.c
         c._axes_manager.indices = (1, 1)
         c.active = False
-        c.enable_pixel_level_switching = True
-        c.enable_pixel_level_switching = False
+        c.active_is_multidimensional = True
+        c.active_is_multidimensional = False
         nose.tools.assert_false(c.active)

--- a/hyperspy/tests/model/test_set_parameter_value.py
+++ b/hyperspy/tests/model/test_set_parameter_value.py
@@ -78,9 +78,9 @@ class TestSetParameterInModel:
         g1 = self.g1
         g2 = self.g2
         g3 = self.g3
-        g1.enable_pixel_level_switching = True
-        g2.enable_pixel_level_switching = True
-        g3.enable_pixel_level_switching = True
+        g1.active_is_multidimensional = True
+        g2.active_is_multidimensional = True
+        g3.active_is_multidimensional = True
         m.set_component_active_value(False)
         assert_true(np.all(np.logical_not(g1._active_array)))
         assert_true(np.all(np.logical_not(g2._active_array)))
@@ -91,9 +91,9 @@ class TestSetParameterInModel:
         g1 = self.g1
         g2 = self.g2
         g3 = self.g3
-        g1.enable_pixel_level_switching = True
-        g2.enable_pixel_level_switching = True
-        g3.enable_pixel_level_switching = True
+        g1.active_is_multidimensional = True
+        g2.active_is_multidimensional = True
+        g3.active_is_multidimensional = True
         m.set_component_active_value(False, component_list=[g1, g2])
         assert_true(np.all(np.logical_not(g1._active_array)))
         assert_true(np.all(np.logical_not(g2._active_array)))
@@ -104,9 +104,9 @@ class TestSetParameterInModel:
         g1 = self.g1
         g2 = self.g2
         g3 = self.g3
-        g1.enable_pixel_level_switching = True
-        g2.enable_pixel_level_switching = True
-        g3.enable_pixel_level_switching = True
+        g1.active_is_multidimensional = True
+        g2.active_is_multidimensional = True
+        g3.active_is_multidimensional = True
         m.set_component_active_value(False,
                                      component_list=[g1],
                                      only_current=True)


### PR DESCRIPTION
Main changes:
- When pixel_level_switching is active, it is not longer necessary to call fetch/store in order to fetch and store the value from/in the array.
- Some modifcations to the User Guide.
- New tests that helped find and fix a couple of bugs.
- Rename `enable_pixel_level_switching` -> `active_is_multidimensional`
- Rename `active_map` to `_active_array`.
